### PR TITLE
Set NBT file type to binary and fix NBT editor with mcdev

### DIFF
--- a/src/main/java/com/github/tth05/minecraftnbtintellijplugin/NBTFileType.java
+++ b/src/main/java/com/github/tth05/minecraftnbtintellijplugin/NBTFileType.java
@@ -37,7 +37,7 @@ public class NBTFileType implements FileType {
 
 	@Override
 	public boolean isBinary() {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/tth05/minecraftnbtintellijplugin/editor/NBTFileEditorProvider.java
+++ b/src/main/java/com/github/tth05/minecraftnbtintellijplugin/editor/NBTFileEditorProvider.java
@@ -1,5 +1,6 @@
 package com.github.tth05.minecraftnbtintellijplugin.editor;
 
+import com.github.tth05.minecraftnbtintellijplugin.NBTFileType;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorPolicy;
 import com.intellij.openapi.fileEditor.FileEditorProvider;
@@ -17,8 +18,7 @@ import java.util.List;
 public class NBTFileEditorProvider implements FileEditorProvider, DumbAware {
 	@Override
 	public boolean accept(@NotNull Project project, @NotNull VirtualFile file) {
-		return FileTypeRegistry.getInstance()
-				.isFileOfType(file, FileTypeRegistry.getInstance().getFileTypeByExtension("nbt"));
+		return FileTypeRegistry.getInstance().isFileOfType(file, NBTFileType.INSTANCE);
 	}
 
 	@NotNull


### PR DESCRIPTION
The issue I saw was two-fold:

 1. `NBTFileType.isBinary` returned `false`, telling IntelliJ that NBT files are text files, even though they aren't. This is why after IntelliJ didn't know what to do with the file it attempted to open the file as text. The reason IntelliJ didn't know what to do with the file was because of the next issue.
 2. `NBTFileEditorProvider.accept` was using `FileTypeRegistry.getFileTypeByExtension("nbt")` to get the file type instead of just accessing the file type directly with `NBTFileType.INSTANCE`. Since mcdev also registered the `nbt` file extension, it just turned out bad luck that mcdev registers after (for some arbitrary ordering rules I'm sure), so the result of that method was returning mcdev's `NbtFileType`.

The two issues above resulted in the issue we saw:

First, IntelliJ assigned the type of the file. It chose your `NBTFileType` due to the `NBTFileTypeOverrider`. Next, it looked for an editor to handle opening the file. It checked all of the editor providers and checked `NBTFileEditorProvider` and found that `NBTFileEditorProvider` does not accept files of type `NBTFileType` because of issue 2. It then checked if the file was a binary file, and determined that it wasn't (which means it's a text file). So it gave the file to the default plain text editor, which attempted to read the file as text.